### PR TITLE
Enable resizable display

### DIFF
--- a/Plinko Project/Plinko Project/main.py
+++ b/Plinko Project/Plinko Project/main.py
@@ -336,7 +336,10 @@ def simulation_loop(running):
 # Display Loop
 def display_loop(running):
     pygame.init()
-    screen = pygame.display.set_mode((int(window_width), int(window_height)))
+    global window_width, window_height
+    screen = pygame.display.set_mode(
+        (int(window_width), int(window_height)), pygame.RESIZABLE
+    )
     clock = pygame.time.Clock()
 
     while running():
@@ -346,6 +349,13 @@ def display_loop(running):
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running_state["value"] = False
+            elif event.type == pygame.VIDEORESIZE:
+                # keep the aspect ratio based on the new width
+                window_width = event.w
+                window_height = (window_width / aspect_ratio[0]) * aspect_ratio[1]
+                screen = pygame.display.set_mode(
+                    (int(window_width), int(window_height)), pygame.RESIZABLE
+                )
 
             elif event.type == pygame.MOUSEBUTTONDOWN:
                 mouse_x, mouse_y = event.pos

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ cd "Plinko Project/Plinko Project"
 python main.py
 ```
 
-A window will open showing the Plinko board. Click anywhere to spawn a new ball. Close the window or quit the program to stop the simulation.
+A window will open showing the Plinko board. The window can be resized and will maintain its original 3:4 aspect ratio. Click anywhere to spawn a new ball. Close the window or quit the program to stop the simulation.
 


### PR DESCRIPTION
## Summary
- allow the Pygame window to be resizable and preserve its 3:4 aspect ratio
- mention resizable window in README

## Testing
- `python -m py_compile 'Plinko Project/Plinko Project/main.py'`

------
https://chatgpt.com/codex/tasks/task_e_684b26cd357c83309ba56aab5e9394f7